### PR TITLE
Base should be at the bottom of libs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -53,7 +53,6 @@ class AbseilConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = [
-            "absl_base",
             "absl_memory",
             "absl_meta",
             "absl_strings",
@@ -77,7 +76,8 @@ class AbseilConan(ConanFile):
             "absl_stacktrace",
             "absl_utility",
             "absl_container",
-            "absl_leak_check"
+            "absl_leak_check",
+            "absl_base",
             ]
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")


### PR DESCRIPTION
Base should be at the bottom of libs, to achieve proper linkage.
Right now this recipe results in linkage errors.