### PR TITLE
Revert "Base should be at the bottom of libs"

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -53,6 +53,7 @@ class AbseilConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = [
+            "absl_base",
             "absl_memory",
             "absl_meta",
             "absl_strings",
@@ -76,8 +77,7 @@ class AbseilConan(ConanFile):
             "absl_stacktrace",
             "absl_utility",
             "absl_container",
-            "absl_leak_check",
-            "absl_base",
+            "absl_leak_check"
             ]
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")


### PR DESCRIPTION
Reverts bincrafters/conan-abseil#2
@r-darwish reported a regression of working linkage due to this change. 
Reverting until we can reconcile which builds are failing for @fulara vs @r-darwish .