### PR TITLE
Remove duplicated libraries

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -54,9 +54,7 @@ class AbseilConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = [
-            "absl_base",
             "absl_synchronization",
-            "absl_strings",
             "absl_malloc_internal",
             "absl_time",
             "absl_strings",

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -4,10 +4,10 @@ cmake_minimum_required(VERSION 2.8.11)
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 file(GLOB SOURCE_FILES *.cpp)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} ${CONAN_TARGETS})
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)


### PR DESCRIPTION
absl_base and absl_strings were defined twice. This did not effect users who used Conan
LIBS. However, users of modern CMake can use conan_basic_setup(TARGETS), which breaks when the same
target is defined twice. The tests were changed to use TARGETS instead of LIBS